### PR TITLE
added EO-College to Educational Material websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Where to discover new SAR libraries and resources.
 
 * Training, Tutorials, Classes & Other Online Educational Material
     * [SAREDU](https://saredu.dlr.de/)
+    * [EO-College](https://eo-college.org/landingpage)
     * [UNAVCO Short Courses](http://www.unavco.org/education/advancing-geodetic-skills/short-courses/2016/2016.html)
     * [Online Class on Microwave Remote Sensing](https://radar.community.uaf.edu/)
-    * [How to do InSAR on ESA's Geoharzard Exploitation Platform](http://www.video.ethz.ch/events/2017/esa.html)
+    * [How to do InSAR on ESA's Geohazard Exploitation Platform](http://www.video.ethz.ch/events/2017/esa.html)
 
 * Processing Recipes for Automatic Product Generation 
     * [ASF Data Recipes](https://www.asf.alaska.edu/data-tools/data-recipes/)


### PR DESCRIPTION
EO-College is the predecessor of SAR-EDU
see e.g. [here](https://github.com/EO-College)

also fixed a typo