### PR TITLE
Adding EOReader library

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Software capable of multiple processing steps
 * [ISCE stack2stamps](http://winsar.unavco.org/software/isce) - Using ISCE (`src/contrib/timeseries/stack2stamps`) as InSAR pre-processor for StaMPS
 * [GIPhT](https://github.com/feigl/gipht) - General Inversion of Phase Technique
 * [RaySAR](https://github.com/StefanJAuer/RaySAR) - 3D Synthetic Aperture Radar (SAR) Simulator
+* [EOReader](https://github.com/sertit/eoreader) - Opensource python library reading optical and SAR sensors, loading and stacking bands in a sensor-agnostic way.
 
 ### InSAR Modelling
 * [pyrocko](https://pyrocko.org) - Offers tools for surface displacement modelling from various finite and extended earthquake dislocation sources.


### PR DESCRIPTION
Adding [EOReader](https://github.com/sertit/eoreader) library.
The documentation can be found [here](https://eoreader.readthedocs.io/en/latest).

## Introduction
**EOReader** is a remote-sensing opensource python library reading optical and SAR sensors, loading and stacking bands, clouds, DEM and index in a sensor-agnostic way. 

## Regarding SAR topic
It aims to allow the user to load in a pythonic-way orthorectified SAR GRD data, by binding ESA SNAP `gpt`.
You can see how EOReader works in real by looking at [this tutorial](https://eoreader.readthedocs.io/en/latest/notebooks/SAR.html).

EOReader reads: 

| Sensor | Product Type | Handled |
| --- | --- | --- |
| `COSMO-Skymed` 1st and 2nd Generation | SCS | ✅ |
| `COSMO-SkyMed` 1st Generation | DGM | ✅ |
| `COSMO-SkyMed` 2nd Generation | DGM | ⚠️ |
| `COSMO-SkyMed` 1st and 2nd Generation | GEC, GTC | ⚠️ | 
| `ICEYE` | SLC | ❌* |
| `ICEYE` |GRD | ✅ | 
| `ICEYE` | ORTHO | 💤 |
| `RADARSAT Constellation Mission` | SLC | ⚠️ | 
| `RADARSAT Constellation Mission` | GRC, GCC, GCD | ⚠️ |
| `RADARSAT Constellation Mission` | GRD | ✅ | 
| `RADARSAT-2` | SLC | ✅| 
| `RADARSAT-2` | SGX, SCN, SCW,<br>SCF, SCS, SSG, SPG | ⚠️ |
| `RADARSAT-2` | SGF | ✅ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | SSC | ✅ | 
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | MGD | ✅ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | GEC | ⚠️ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | EEC | ✅ |
| `Sentinel-1` | SLC | ✅ | 
| `Sentinel-1` | GRD | ✅ |

\**always given with a GRD image*

✅: Tested   
⚠️: Never tested, **use it at your own risk!**  
❌: Not handled   
💤: Waiting for the release  

Those sensors are planned in a near future:
- `SAOCOM-1`

## Context

This library has been created in the context of the Copernicus Emergency Management Service rapid mapping and risk and recovery.

In these activations, it is needed to deliver information (such as flood or fire delineations, landslides mapping, etc.) based on various sensors (optical and SAR). As every minute counts in production, it seemed crucial to harmonize the ground on which are built our production tools, in order to make them as sensor-agnostic as possible.