### PR TITLE
Add EQ-INSAR - synthetic InSAR generator for earthquake ML training

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Software capable of multiple processing steps
 * [pyrocko](https://pyrocko.org) - Offers tools for surface displacement modeling from various finite and extended earthquake dislocation sources.
 * [grond](https://pyrocko.org) - Modern probabilistic surface displacement inversion (works with [kite](https://github.com/pyrocko/kite)).
 * [SARscape](https://www.sarmap.ch/index.php/software/sarscape/) - SARscape provides models for the analytic modeling of geophysical sources developed in collaboration with INGV.
+* [EQ-INSAR](https://github.com/kcieslik/eq-insar) - Synthetic InSAR data generator for machine learning from earthquake source parameters.
 
 ### System configuration and installation
 * [insar_instal](https://github.com/mgovorcin/insar_inst) - Set of scripts that automatically install InSAR software


### PR DESCRIPTION
 ## Adding EQ-INSAR

  **Link:** https://github.com/kcieslik/eq-insar
  **PyPI:** https://pypi.org/project/eq-insar/
  **Preprint:** https://doi.org/10.31223/X5T19M

  EQ-INSAR is an open-source Python package that generates synthetic InSAR
  interferograms from earthquake point sources (Davis 1986 elastic half-space
  model). It supports 9 SAR satellite geometries (Sentinel-1, ALOS-2,
  TerraSAR-X, etc.) and is specifically designed for ML training data
  generation — producing labeled time series with binary segmentation masks
  in (N, T, H, W) format for PyTorch/TensorFlow.

  Key facts:
  - NumPy-only core (no heavy dependencies)
  - MIT license, published on PyPI
  - Archived on Zenodo (DOI: 10.5281/zenodo.18647189)
  - Peer-reviewed preprint on EarthArXiv

  Placed under: Radar-Related GitHub Repos > InSAR modeling tools